### PR TITLE
BAH-4175 | Fix. Remove parent POM configuration as it overrides distributionManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.openmrs.maven.parents</groupId>
-        <artifactId>maven-parent-openmrs-module</artifactId>
-        <version>1.1.1</version>
-    </parent>
-
     <groupId>org.bahmni.module</groupId>
     <artifactId>communication</artifactId>
     <packaging>pom</packaging>


### PR DESCRIPTION
This PR removes the parent pom configuration which points to [openmrs parent module](https://github.com/openmrs/openmrs-contrib-maven-parent-module). This parent configuration brings a distributionManagement section which is not applicable for Bahmni.